### PR TITLE
Add build.rs file

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,13 @@
+use std::process::Command;
+
+#[allow(dead_code)]
+fn main() {
+    let project_root = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let input_css_path: String = [&project_root, "/css/input.css"].iter().map(|s| *s).collect();
+    let output_css_path: String = [&project_root, "/css/output.css"].iter().map(|s| *s).collect();
+
+    Command::new("npx")
+        .args(["tailwindcss", "-i", &input_css_path, "-o", &output_css_path])
+        .output()
+        .expect("Failed to build tailwind");
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,5 +3,5 @@ main = "build/worker/shim.mjs"
 compatibility_date = "2024-05-22"
 
 [build]
-command = "cargo install -q worker-build && npx tailwindcss -i ./css/input.css -o ./css/output.css && worker-build --release"
+command = "cargo install -q worker-build && worker-build --release"
 watch_dir = [ "src", "templates" ]


### PR DESCRIPTION
Remove the tailwind command from wrangler.toml and let rust build system invoke this, so that in the future this can be programmatically disabled, if needed.